### PR TITLE
Add shell ESV syntax to esv lexer

### DIFF
--- a/metaborg/pygments/lexers/meta/esv.py
+++ b/metaborg/pygments/lexers/meta/esv.py
@@ -12,6 +12,7 @@ class ESVLexer(RegexLexer):
             (words(('module','imports',
                     'language','name','description','extensions','table','start','symbols','provider','observer','context',
                     'menus','menu','action','openeditor','source','meta','realtime',
+                    'shell','evaluation method','shell start symbol',
                     'line comment','block comment','fences'), suffix=r'\b'), Keyword),
             (r'"[^"^\n]*"', Literal.String),
             (r'[\.\,\|\[\]\(\)\{\}\<\>\;\:\*]', Text.Punctuation),


### PR DESCRIPTION
This extends the pygments lexer for ESV with the new configuration options for the REPL, so that the example in the documentation (see metaborg/documentation#6) is highlighted.
